### PR TITLE
Remove FULFILLMENT peer from GET_SALESORDER

### DIFF
--- a/config/channel-settings.json
+++ b/config/channel-settings.json
@@ -526,12 +526,6 @@
             "location": "order.customer",
             "remoteID": "id",
             "businessReferences": ["email", "phone"]
-          },
-          {
-            "name": "FULFILLMENT",
-            "location": "order.fulfillments",
-            "remoteID": "id",
-            "businessReferences": ["id"]
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nchannel/shopify-channel",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npx nchannel-sdk test"
   },
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "Shopify.js",
   "files": [
     "config",


### PR DESCRIPTION
When a sales order is retrieved from shopify, after having been fulfilled, the FULFILLMENT object in gateway-storage is being updated (incorrectly) and the businessReference property is set to the fulfillment id. This causes subsequent UPDATE_FULFILLMENT operations to take the insert path since the fulfillment can not be found in gateway-storage.